### PR TITLE
Save space by deleting proc/ and S3/ files, keep only mosaic/

### DIFF
--- a/S3_wrapper.sh
+++ b/S3_wrapper.sh
@@ -78,3 +78,7 @@ EOF
 
   done
 done
+
+
+rm -fR ${SEN3_source}/*
+rm -fR ${proc_root}/*

--- a/S3_wrapper.sh
+++ b/S3_wrapper.sh
@@ -75,10 +75,12 @@ EOF
       rm -fR ${tmpdir}
       cd ${_cwd}
     fi
+    
+    cd ${SEN3_source}; rm ${SEN3_source}/${year}/${date}
+    cd ${proc_root}; rm ${proc_root}/${date}
 
   done
 done
 
 
-rm -fR ${SEN3_source}/*
-rm -fR ${proc_root}/*
+


### PR DESCRIPTION
In the case of big runs, storage space can be problematic. Deleting temporary outputs could be a solution.