### PR TITLE
Gaps condition

### DIFF
--- a/S3_wrapper.sh
+++ b/S3_wrapper.sh
@@ -34,16 +34,12 @@ for year in 2018 2017; do
     fi
     
     # # # Fetch one day of OLCI & SLSTR scenes over Greenland
-    if [[ ! -d "${SEN3_source}/${year}/${date}" ]]; then
-      mkdir -p ${SEN3_source}/${year}/${date}
-      # ./dhusget_wrapper.sh -d ${date} -l ${SEN3_local} -o ${SEN3_source}/${year}/${date}
-      ./dhusget_wrapper.sh -d ${date} -o ${SEN3_source}/${year}/${date}
-    fi
+    mkdir -p ${SEN3_source}/${year}/${date}
+    # ./dhusget_wrapper.sh -d ${date} -l ${SEN3_local} -o ${SEN3_source}/${year}/${date}
+    ./dhusget_wrapper.sh -d ${date} -o ${SEN3_source}/${year}/${date}
     
     # SNAP: Reproject, calculate reflectance, extract bands, etc.
-    if [[ ! -d "${proc_root}/${date}" ]]; then
-      ./S3_proc.sh -i ${SEN3_source}/${year}/${date} -o ${proc_root}/${date} -X S3.xml -t
-    fi
+    ./S3_proc.sh -i ${SEN3_source}/${year}/${date} -o ${proc_root}/${date} -X S3.xml -t
     
     # SICE
     # Does SnBBA exist already in every folder?

--- a/S3_wrapper.sh
+++ b/S3_wrapper.sh
@@ -27,7 +27,12 @@ for year in 2018 2017; do
 #   for doy in 227 180; do  # 2017-08-15=227
 
     date=$(date -d "${year}-01-01 +$(( 10#${doy}-1 )) days" "+%Y-%m-%d")
-
+    
+    if [[ -d "${mosaic_root}/${date}" ]]; then
+      echo "${mosaic_root}/${date} already exists, date skipped"
+      continue
+    fi
+    
     # # # Fetch one day of OLCI & SLSTR scenes over Greenland
     if [[ ! -d "${SEN3_source}/${year}/${date}" ]]; then
       mkdir -p ${SEN3_source}/${year}/${date}


### PR DESCRIPTION
If a given date is already computed, move on to the next one.
Therefore, it's possible to run over a given duration and only compute missing dates.