### PR TITLE
Use SCDA NDSI

### DIFF
--- a/dm.grass.sh
+++ b/dm.grass.sh
@@ -126,8 +126,6 @@ parallel "r.out.gdal -m -c input={} output=${outfolder}/${date}/{}.tif ${tifopts
 
 # Generate some extra rasters
 tifopts='type=Float32 createopt=COMPRESS=DEFLATE,PREDICTOR=2,TILED=YES --q --o'
-r.mapcalc "ndsi = ( r_TOA_17 - r_TOA_21 ) / ( r_TOA_17 + r_TOA_21 )"
-r.out.gdal -f -m -c input=ndsi output=${outfolder}/${date}/NDSI.tif ${tifopts}
 
 r.mapcalc "ndbi = ( r_TOA_01 - r_TOA_21 ) / ( r_TOA_01 + r_TOA_21 )"
 r.out.gdal -f -m -c input=ndbi output=${outfolder}/${date}/NDBI.tif ${tifopts}


### PR DESCRIPTION
In the previous pull request https://github.com/mankoff/SICE/commit/33e3c20d3c6ece58cc35e36c2028c6dc12506a46, the NDSI based on r_TOAs has been evaluated as incorrect and as a consequence, removed. Only the SCDA NDSI has been kept. It has been added again in the latest PR https://github.com/mankoff/SICE/pull/46, maybe by mistake.